### PR TITLE
Add Pull Request template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,21 @@
+### Description
+
+Please include a summary of the changes and the related issue. 
+
+Fixes # (_issue_number_)
+
+### Type of change
+
+Please select the type of change(s) this PR introduces:
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Documentation update
+
+### Checklist
+
+- [ ] I have read the [Contributing Guidelines](/CONTRIBUTING.md) document
+
+### Additional Information
+
+Please provide any additional information or context if necessary.


### PR DESCRIPTION
This pull request added new PR template file(md). To guide and help contributors in providing details about their pull requests.

Enhancements to pull request template:

* [`.github/pull_request_template.md`](diffhunk://#diff-b2496e80299b8c3150b1944450bd81c622e04e13d15c411d291db0927d75fd6bR1-R21): Added sections for description, type of change, checklist, and additional information to ensure contributors provide thorough and consistent details.

