### PR TITLE
docs(contributing): contributors are required to sign commits

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -2,7 +2,11 @@
 
 Please include a summary of the changes and the related issue. 
 
-Fixes # (_issue_number_)
+Fixes #<issue number>
+<!---
+Related to #<issue number>
+Depends on #<issue number>
+-->
 
 ### Type of change
 
@@ -10,11 +14,14 @@ Please select the type of change(s) this PR introduces:
 - [ ] Bug fix (non-breaking change which fixes an issue)
 - [ ] New feature (non-breaking change which adds functionality)
 - [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] Code clean up
 - [ ] Documentation update
 
 ### Checklist
 
 - [ ] I have read the [Contributing Guidelines](/CONTRIBUTING.md) document
+- [ ] I have include additional documentations if the PR includes user-facing changes
+- [ ] I have signed my commits. See [references](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) for more details
 
 ### Additional Information
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,6 +20,7 @@ We appreciate all contributions, whether they involve a large feature, a bug fix
 - Open a new GitHub pull request with the patch.
 
 - Ensure the PR description clearly describes the problem and solution. Include the relevant issue number in PR description if applicable (e.g. `Fixes #100`, `Related to #101`).
+- **All commmits must be signed. See [references](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) for more details.**
 
 - The maintainers will get to your as soon as possible.
 


### PR DESCRIPTION
### Description

This added a requirement for contributors to sign their commits.

Related to #5 

### Type of change

Please select the type of change(s) this PR introduces:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update

### Checklist

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md) document

### Additional Information

N/A