### PR TITLE
test(e2e): add e2e test case for edit cmd

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,6 +67,7 @@ endif
 
 ## E2E Tests
 TEST_BIN := $(shell pwd)/testbin
+E2E_SKIP_SETUP ?= false
 
 .PHONY: test-e2e
 test-e2e: build e2e-setup ginkgo ## Run e2e tests.
@@ -77,7 +78,9 @@ endif
 .PHONY: e2e-setup
 e2e-setup: ## Setting up environment for e2e tests.
 ifneq ($(SKIP_TESTS), true)
+ifneq ($(E2E_SKIP_SETUP), true)
 	./scripts/e2e_setup.sh
+endif
 endif
 
 .PHONY: e2e-teardown

--- a/docs/DEVELOPER_GUIDES.md
+++ b/docs/DEVELOPER_GUIDES.md
@@ -7,6 +7,7 @@ The guide describes workflow for developing the plugin. Feel free to suggest any
 - Linux distros (e.g. Fedora, Ubuntu)
 - [Go](https://go.dev/doc/install) `v1.22`
 - Make
+- [yq](https://mikefarah.gitbook.io/yq#install) `v4+`
 - Kubernetes `>= v1.25.0-0` (e.g. [minikube](https://minikube.sigs.k8s.io/docs/) or [CRC](https://developers.redhat.com/products/openshift-local/getting-started))
 
 ### Fork the repository
@@ -46,6 +47,12 @@ make test
 ```
 
 A coverage report will created at `cover.out`.
+
+To execute E2E tests, run:
+
+```bash
+make test-e2e
+```
 
 ### Run lints
 

--- a/scripts/e2e_cleanup.sh
+++ b/scripts/e2e_cleanup.sh
@@ -4,7 +4,10 @@
 
 DEFAULT_CLUSTER_NAME=ephcont-e2e
 
-BIN="$(pwd)/testbin"
+# Directory scripts
+DIR="$(dirname "$(readlink -f "$0")")"
+BIN="$DIR/../testbin"
+
 KEEP_TOOLS=${KEEP_TOOLS:-true}
 
 main() {

--- a/scripts/e2e_setup.sh
+++ b/scripts/e2e_setup.sh
@@ -6,7 +6,9 @@ DEFAULT_KUBECTL_VERSION=v1.30.0
 DEFAULT_KIND_VERSION=v0.24.0
 DEFAULT_CLUSTER_NAME=ephcont-e2e
 
-BIN="$(pwd)/testbin"
+# Directory scripts
+DIR="$(dirname "$(readlink -f "$0")")"
+BIN="$DIR/../testbin"
 
 # Entry point
 main() {
@@ -36,6 +38,9 @@ main() {
 
     echo "Installing kubectl..."
     install_kubectl
+
+    echo "Installing custom editor..."
+    install_custom_editor
 
     echo "Creating KinD cluster..."
     create_cluster
@@ -111,10 +116,15 @@ install_kubectl() {
     fi
 }
 
+install_custom_editor() {
+    cp "$DIR/e2e_vim.sh" "$BIN/vi"
+    chmod +x "$BIN/vi"
+}
+
 # Create a KinD cluster
 # and write client configurations to testbin/kubeconfig
 create_cluster() {
-    KUBECONFIG="$BIN/kubeconfig" "$BIN/kind" create cluster --config "$config" --name "$cluster_name"
+    KUBECONFIG="$BIN/kubeconfig" "$BIN/kind" create cluster --config "$config" --name "$cluster_name" 2>/dev/null
 }
 
 check_tool_available() {

--- a/scripts/e2e_vim.sh
+++ b/scripts/e2e_vim.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# This is a custom editor used for e2e tests
+# Requirements
+# - yq (v4)
+# Note: The patches are predefined
+
+if ! command -v yq >/dev/null 2>&1; then
+    echo "yq is required, but missing. Install guide: https://mikefarah.gitbook.io/yq#install"
+    exit 1
+fi
+
+# Path to temporary file containing Pod's manifest
+pod_manifest="$1"
+
+# Constants
+export container_image=${container_image:-"docker.io/library/busybox:1.28"}
+export container_name=${container_name:-"debugger-$RANDOM"}
+export other_container_image=${other_container_image:-"docker.io/library/busybox:1.27"}
+
+# Path to patch to apply to Pod manifest
+case "${E2E_EDIT_ACTION:-""}" in
+    add)
+        # Add a new container
+        container_spec="{\"image\": \"$container_image\", \"name\": \"$container_name\", \"imagePullPolicy\": \"IfNotPresent\", \"stdin\": true, \"tty\": true}"
+        yq -i ".spec.ephemeralContainers |= . + [$container_spec]" "$pod_manifest"
+    ;;
+    delete)
+        # Delete a container (assuming one is available)
+        yq -i 'del(.spec.ephemeralContainers[0])' "$pod_manifest"
+    ;;
+    modify)
+        # Modify container image (assuming one is available)
+        yq -i '.spec.ephemeralContainers[0].image |= env(other_container_image)' "$pod_manifest"
+    ;;
+    *)
+        exit 0
+    ;;
+esac


### PR DESCRIPTION
### Description

Added e2e tests for edit cmd. To workaround interactive user input, we implements a simple custom editor that stimulate changes to pod manifests.


Fixes #33 
<!---
Related to #<issue number>
Depends on #<issue number>
-->

### Type of change

Please select the type of change(s) this PR introduces:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Code clean up
- [x] Tests
- [ ] Documentation update

### Checklist

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md) document
- [x] I have include additional documentations if the PR includes user-facing changes
- [x] I have signed my commits. See [references](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) for more details

### Additional Information
N/A
