### PR TITLE
test(e2e): e2e test cases for listing pods in all namespaces

### DIFF
--- a/e2e/e2e_suite_test.go
+++ b/e2e/e2e_suite_test.go
@@ -15,6 +15,7 @@
 package e2e_test
 
 import (
+	"fmt"
 	"testing"
 
 	. "github.com/k8s-crafts/ephemeral-containers-plugin/e2e/testutils"
@@ -38,14 +39,23 @@ var _ = BeforeSuite(func() {
 	tr, err = NewTestResource()
 	Expect(err).ToNot(HaveOccurred())
 
+	By("checking if kube API meets minimum required version")
 	// Check if the kube API is supported
 	Expect(tr.IsKubeAPICompatible()).To(BeTrue())
 
 	// Create resources for tests
-	Expect(tr.CreateNamespace()).ToNot(HaveOccurred())
-	Expect(tr.CreateServiceAccount()).ToNot(HaveOccurred())
+	for _, ns := range tr.GetTestNamespaces() {
+		By(fmt.Sprintf("creating namespace %s and test resources", ns))
+
+		Expect(tr.CreateNamespace(ns)).ToNot(HaveOccurred())
+		Expect(tr.CreateServiceAccount(ns)).ToNot(HaveOccurred())
+	}
 })
 
 var _ = AfterSuite(func() {
-	Expect(tr.DeleteNamespace()).ToNot(HaveOccurred())
+	for _, ns := range tr.GetTestNamespaces() {
+		By(fmt.Sprintf("deleting namespace %s", ns))
+
+		Expect(tr.DeleteNamespace(ns)).ToNot(HaveOccurred())
+	}
 })

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -24,40 +24,79 @@ import (
 
 var _ = Describe("kubectl ephemeral-containers", func() {
 	BeforeEach(func() {
-		Expect(tr.CreateTestPod()).ToNot(HaveOccurred())
-		Expect(tr.WaitForPodReady()).ToNot(HaveOccurred())
+		for _, ns := range tr.GetTestNamespaces() {
+			By(fmt.Sprintf("creating and waiting for test pod in namespace %s", ns))
+
+			Expect(tr.CreateTestPod(ns)).ToNot(HaveOccurred())
+			Expect(tr.WaitForTestPodReady(ns)).ToNot(HaveOccurred())
+		}
 	})
 
 	AfterEach(func() {
-		Expect(tr.DeleteTestPod()).ToNot(HaveOccurred())
+		for _, ns := range tr.GetTestNamespaces() {
+			By(fmt.Sprintf("deleting test pod in namespace %s", ns))
+
+			Expect(tr.DeleteTestPod(ns)).ToNot(HaveOccurred())
+		}
 	})
 
 	Context("list", func() {
-		When("there is no ephemeral container", func() {
-			It("should return empty message", func() {
-				actual, err := tr.RunPluginListCmd("")
-				Expect(err).ToNot(HaveOccurred())
-				Expect(actual).To(Equal(fmt.Sprintf("No pods with ephemeral containers found in namespace %s\n", tr.Kubectl.Namespace)))
+		commonTests := func(allNamespace bool) {
+			var namespace string
+
+			BeforeEach(func() {
+				// Leave namespace empty if in all-namespace mode
+				if !allNamespace {
+					namespace = tr.Kubectl.Namespace
+				}
 			})
-		})
-		When("there are ephemeral containers", func() {
-			DescribeTable("should list in expected format", func(format string) {
-				Expect(tr.RunDebugContainer(true)).ToNot(HaveOccurred())
 
-				actual, err := tr.RunPluginListCmd(format)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(actual).To(Equal(tr.NewListOutput(format)))
-			},
-				Entry("in Table", ""),
-				Entry("in JSON", "json"),
-				Entry("in YAML", "yaml"),
-			)
+			When("there is no ephemeral container", func() {
+				It("should return empty message", func() {
+					By("running kubectl ephemeral-containers list")
+
+					actual, err := tr.RunPluginListCmd("", namespace)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(actual).To(Equal(tr.NewListEmptyMessage(namespace)))
+				})
+			})
+
+			When("there are ephemeral containers", func() {
+				JustBeforeEach(func() {
+					for _, ns := range tr.GetTestNamespaces() {
+						By(fmt.Sprintf("adding an ephemeral container  to test pod in namespace %s", ns))
+
+						Expect(tr.RunDebugContainerForTestPod(ns, testutils.EphContainerName, true)).ToNot(HaveOccurred())
+					}
+				})
+
+				DescribeTable("should list in expected format", func(format string) {
+					By("running kubectl ephemeral-containers list")
+
+					actual, err := tr.RunPluginListCmd(format, namespace)
+					Expect(err).ToNot(HaveOccurred())
+					Expect(actual).To(Equal(tr.NewListOutput(format, namespace)))
+				},
+					Entry("in Table", ""),
+					Entry("in JSON", "json"),
+					Entry("in YAML", "yaml"),
+				)
+			})
+		}
+
+		Context("in a namespace", func() {
+			commonTests(false)
 		})
 
+		Context("in all namespaces", func() {
+			commonTests(true)
+		})
 	})
 
 	Context("help", func() {
 		DescribeTable("should print help message for command", func(subCmd string) {
+			By("running kubectl ephemeral-containers help")
+
 			actual, err := tr.RunPluginHelpCmd(subCmd)
 
 			Expect(err).ToNot(HaveOccurred())
@@ -80,7 +119,11 @@ var _ = Describe("kubectl ephemeral-containers", func() {
 
 	Context("edit", func() {
 		JustBeforeEach(func() {
-			Expect(tr.RunDebugContainer(true)).ToNot(HaveOccurred())
+			for _, ns := range tr.GetTestNamespaces() {
+				By(fmt.Sprintf("adding an ephemeral container  to test pod in namespace %s", ns))
+
+				Expect(tr.RunDebugContainerForTestPod(ns, testutils.EphContainerName, true)).ToNot(HaveOccurred())
+			}
 		})
 
 		AfterEach(func() {
@@ -94,7 +137,9 @@ var _ = Describe("kubectl ephemeral-containers", func() {
 			})
 
 			It("should print a message", func() {
-				actual, err := tr.RunPluginEditCmd(testutils.PodName)
+				By("running kubectl ephemeral-containers edit")
+
+				actual, err := tr.RunPluginEditCmd(tr.Kubectl.Namespace, testutils.TestPodName)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(actual).To(Equal(fmt.Sprintf("Edit cancelled, no changes made for pod/%s\n", testutils.PodName)))
@@ -107,7 +152,9 @@ var _ = Describe("kubectl ephemeral-containers", func() {
 			})
 
 			It("should fail with Forbidden error", func() {
-				actual, err := tr.RunPluginEditCmd(testutils.PodName)
+				By("running kubectl ephemeral-containers edit")
+
+				actual, err := tr.RunPluginEditCmd(tr.Kubectl.Namespace, testutils.TestPodName)
 
 				Expect(err).To(HaveOccurred())
 				Expect(actual).To(ContainSubstring(fmt.Sprintf("Pod \"%s\" is invalid: spec.ephemeralContainers: Forbidden: existing ephemeral containers \"%s\" may not be changed", testutils.PodName, testutils.EphContainerName)))
@@ -120,7 +167,9 @@ var _ = Describe("kubectl ephemeral-containers", func() {
 			})
 
 			It("should fail with Forbidden error", func() {
-				actual, err := tr.RunPluginEditCmd(testutils.PodName)
+				By("running kubectl ephemeral-containers edit")
+
+				actual, err := tr.RunPluginEditCmd(tr.Kubectl.Namespace, testutils.TestPodName)
 
 				Expect(err).To(HaveOccurred())
 				Expect(actual).To(ContainSubstring(fmt.Sprintf("Pod \"%s\" is invalid: spec.ephemeralContainers: Forbidden: existing ephemeral containers \"%s\" may not be removed", testutils.PodName, testutils.EphContainerName)))
@@ -134,12 +183,14 @@ var _ = Describe("kubectl ephemeral-containers", func() {
 			})
 
 			It("should succeed with a message", func() {
-				actual, err := tr.RunPluginEditCmd(testutils.PodName)
+				By("running kubectl ephemeral-containers edit")
+
+				actual, err := tr.RunPluginEditCmd(tr.Kubectl.Namespace, testutils.TestPodName)
 
 				Expect(err).ToNot(HaveOccurred())
 				Expect(actual).To(Equal(fmt.Sprintf("pod/%s successfully edited\n", testutils.TestPodName)))
 
-				names, err := tr.ListEphemeralContainerNamesForTestPod()
+				names, err := tr.ListEphemeralContainerNamesForTestPod(tr.Kubectl.Namespace)
 				Expect(err).ToNot(HaveOccurred())
 
 				Expect(names).To(ContainSubstring(testutils.EphContainerName))


### PR DESCRIPTION
### Description

- Added E2E tests for `list` subcommand in `--all-namespace` mode.
- Added [`By`](https://onsi.github.io/ginkgo/#documenting-complex-specs-by) constructs to better explain the test specs.

Related to #4 

### Type of change

Please select the type of change(s) this PR introduces:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code clean up
- [x] Tests
- [ ] Documentation update

### Checklist

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md) document
- [x] I have include additional documentations if the PR includes user-facing changes
- [x] I have signed my commits. See [references](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) for more details

### Additional Information

N/A
