### PR TITLE
test(k8s): unit tests for k8s pkg

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -22,7 +22,6 @@ import (
 	"github.com/k8s-crafts/ephemeral-containers-plugin/pkg/k8s"
 	"github.com/k8s-crafts/ephemeral-containers-plugin/pkg/out"
 	"github.com/spf13/cobra"
-	"k8s.io/cli-runtime/pkg/genericclioptions"
 	_ "k8s.io/client-go/plugin/pkg/client/auth"
 )
 
@@ -54,8 +53,7 @@ func NewRootCmd() *cobra.Command {
 			}
 			kubeConfig.Namespace = &ns
 
-			kubeConfig.ContextOptions = k8s.NewContextOptions()
-			if err := kubeConfig.ContextOptions.Init(kubeConfig.Timeout); err != nil {
+			if err := kubeConfig.InitContext(kubeConfig.Timeout); err != nil {
 				ExitError(err, 1)
 			}
 		},
@@ -93,5 +91,5 @@ func ExitError(err error, exitCode int) {
 }
 
 func init() {
-	kubeConfig = k8s.NewKubeConfig(genericclioptions.NewConfigFlags(true))
+	kubeConfig = k8s.NewKubeConfig()
 }

--- a/pkg/k8s/client.go
+++ b/pkg/k8s/client.go
@@ -38,15 +38,10 @@ type ContextOptions struct {
 	SigChan chan os.Signal
 }
 
-// Get a new ContextOptions struct
-func NewContextOptions() *ContextOptions {
-	return &ContextOptions{}
-}
-
 // Set up the options with the following steps:
 // * Create a Context with timeout if any. Otherwise, no timeout is set (i.e. context.Background())
 // * Create a chan os.Signal to handle SIGTERM, SIGINT (Ctrl + C),SIGHUP (terminal is closed)
-func (opts *ContextOptions) Init(timeout *string) error {
+func (opts *ContextOptions) InitContext(timeout *string) error {
 	// Global context
 	var ctx context.Context
 	var cancel context.CancelFunc
@@ -89,13 +84,14 @@ func (opts *ContextOptions) Init(timeout *string) error {
 // Represent kube client configurations
 type KubeConfig struct {
 	*genericclioptions.ConfigFlags
-	ContextOptions *ContextOptions
+	*ContextOptions
 }
 
 // Get a new KubeConfig struct
-func NewKubeConfig(configFlags *genericclioptions.ConfigFlags) *KubeConfig {
+func NewKubeConfig() *KubeConfig {
 	return &KubeConfig{
-		ConfigFlags: configFlags,
+		ConfigFlags:    genericclioptions.NewConfigFlags(true),
+		ContextOptions: &ContextOptions{},
 	}
 }
 
@@ -116,6 +112,6 @@ func NewClientset(kubeConfig *KubeConfig) (*KubeClientset, error) {
 	}
 
 	return &KubeClientset{
-		Clientset: _clientset,
+		Interface: _clientset,
 	}, nil
 }

--- a/pkg/k8s/k8s_suite_test.go
+++ b/pkg/k8s/k8s_suite_test.go
@@ -1,0 +1,27 @@
+// Copyright 2024 k8s-crafts Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// 	http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestK8s(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "K8s Suite")
+}

--- a/pkg/k8s/k8s_test.go
+++ b/pkg/k8s/k8s_test.go
@@ -1,0 +1,194 @@
+// Copyright 2024 k8s-crafts Authors
+
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+
+// 	http://www.apache.org/licenses/LICENSE-2.0
+
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package k8s_test
+
+import (
+	"context"
+	"os"
+	"path"
+
+	"github.com/k8s-crafts/ephemeral-containers-plugin/pkg/k8s"
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/client-go/kubernetes/fake"
+)
+
+var _ = Describe("K8s", func() {
+	var t *test
+
+	BeforeEach(func() {
+		t = newTest()
+	})
+
+	JustBeforeEach(func() {
+		for _, ns := range t.namespaces {
+
+			testNs := t.newNamespace(ns)
+			testPod := t.newPod("testpod", ns)
+
+			_, err := t.clientset.CoreV1().Namespaces().Create(context.Background(), testNs, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+
+			_, err = t.clientset.CoreV1().Pods(ns).Create(context.Background(), testPod, metav1.CreateOptions{})
+			Expect(err).ToNot(HaveOccurred())
+		}
+	})
+
+	When("creating Kubernetes clientset", func() {
+		BeforeEach(func() {
+			t.setEnvKubeConfig()
+		})
+
+		AfterEach(func() {
+			t.UnsetEnvKubeConfig()
+		})
+
+		It("should create a non-nil kubeconfig", func() {
+			kubeConfig := k8s.NewKubeConfig()
+			t.expectKubeConfig(kubeConfig)
+		})
+
+		It("should create a clientset", func() {
+			kubeConfig := k8s.NewKubeConfig()
+			t.expectKubeConfig(kubeConfig)
+
+			clientset, err := k8s.NewClientset(kubeConfig)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(clientset).ToNot(BeNil())
+		})
+	})
+
+	When("listing pods", func() {
+		Context("in a namespace", func() {
+			It("should return pods", func() {
+				pods, err := t.clientset.ListPods(context.Background(), t.namespaces[0])
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pods).To(HaveLen(1))
+			})
+		})
+		Context("in all namespaces", func() {
+			It("should return pods", func() {
+				pods, err := t.clientset.ListPods(context.Background(), "")
+				Expect(err).ToNot(HaveOccurred())
+				Expect(pods).To(HaveLen(2))
+			})
+		})
+	})
+
+	When("getting a pod", func() {
+		It("should return the pod", func() {
+			pod, err := t.clientset.GetPod(context.Background(), t.namespaces[0], "testpod")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pod).ToNot(BeNil())
+
+			Expect(pod.Kind).To(Equal("Pod"))
+			Expect(pod.Name).To(Equal("testpod"))
+			Expect(pod.Namespace).To(Equal(t.namespaces[0]))
+
+		})
+	})
+
+	When("updating the ephemeralcontainer subresource for a pod", func() {
+		It("should update", func() {
+			pod, err := t.clientset.GetPod(context.Background(), t.namespaces[0], "testpod")
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pod).ToNot(BeNil())
+
+			newCont := corev1.EphemeralContainer{
+				EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+					Name:  "debugger",
+					Image: "busybox:1.27",
+				},
+			}
+
+			pod.Spec.EphemeralContainers = append(pod.Spec.EphemeralContainers, newCont)
+
+			pod, err = t.clientset.UpdateEphemeralContainersForPod(context.Background(), pod)
+			Expect(err).ToNot(HaveOccurred())
+			Expect(pod).ToNot(BeNil())
+
+			Expect(pod.Spec.EphemeralContainers).To(ContainElement(newCont))
+		})
+	})
+})
+
+type testInput struct {
+	clientset  *k8s.KubeClientset
+	namespaces []string
+}
+
+type test struct {
+	*testInput
+}
+
+func newTest() *test {
+	return &test{
+		testInput: &testInput{
+			namespaces: []string{"test-ns-0", "test-ns-1"},
+			clientset: &k8s.KubeClientset{
+				Interface: fake.NewClientset(),
+			},
+		},
+	}
+}
+
+func (t *test) newNamespace(name string) *corev1.Namespace {
+	return &corev1.Namespace{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: name,
+		},
+	}
+}
+
+func (t *test) newPod(name, namespace string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+		Spec: corev1.PodSpec{
+			EphemeralContainers: []corev1.EphemeralContainer{
+				{
+					EphemeralContainerCommon: corev1.EphemeralContainerCommon{
+						Name:  "debugger",
+						Image: "busybox:1.28",
+					},
+				},
+			},
+			Containers: []corev1.Container{
+				{
+					Name:  "main",
+					Image: "registry.k8s.io/pause:3.1",
+				},
+			},
+		},
+	}
+}
+
+func (t *test) expectKubeConfig(kubeConfig *k8s.KubeConfig) {
+	Expect(kubeConfig).ToNot(BeNil())
+	Expect(kubeConfig.ConfigFlags).ToNot(BeNil())
+}
+
+func (t *test) setEnvKubeConfig() {
+	Expect(os.Setenv("KUBECONFIG", path.Join("testdata", "kubeconfig"))).ToNot(HaveOccurred())
+
+}
+
+func (t *test) UnsetEnvKubeConfig() {
+	Expect(os.Unsetenv("KUBECONFIG")).ToNot(HaveOccurred())
+}

--- a/pkg/k8s/pods.go
+++ b/pkg/k8s/pods.go
@@ -30,7 +30,7 @@ import (
 type PodFilterFn func(pod corev1.Pod) bool
 
 type KubeClientset struct {
-	*kubernetes.Clientset
+	kubernetes.Interface
 }
 
 // List pods by filters in the specified namespace

--- a/pkg/k8s/testdata/kubeconfig
+++ b/pkg/k8s/testdata/kubeconfig
@@ -1,0 +1,20 @@
+apiVersion: v1
+clusters:
+- cluster:
+    insecure-skip-tls-verify: true
+    server: https://127.0.0.1:6443
+  name: development
+contexts:
+- context:
+    cluster: development
+    namespace: unittest
+    user: developer
+  name: dev-unittest
+current-context: dev-unittest
+kind: Config
+preferences: {}
+users:
+- name: developer
+  user:
+    password: some-password
+    username: developer


### PR DESCRIPTION
### Description

Added unit tests for `k8s` package with various code clean up. Notable, the wrapped clientset type now uses `kubernetes.Interface` instead of concreate type. This allows injecting fake client in tests.

Related to #7 

### Type of change

Please select the type of change(s) this PR introduces:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code clean up
- [x] Tests
- [ ] Documentation update

### Checklist

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md) document
- [x] I have include additional documentations if the PR includes user-facing changes
- [x] I have signed my commits. See [references](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) for more details

### Additional Information

N/A