### PR TITLE
test(unit): add assertions for command flags

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ export PLUGIN_VERSION=v$(VERSION)
 ## Tool versions
 GO_LICENSE_VERSION ?= 1.39.0
 GOLANGCI_LINT_VERSION ?= 1.61.0
-GINKGO_VERSION ?= 2.21.0 # Using ginkgo v2
+GINKGO_VERSION ?= 2.22.1 # Using ginkgo v2
 
 ## Other flags
 SKIP_TESTS ?= false
@@ -69,7 +69,7 @@ test-all: test-unit test-e2e ## Run all tests (i.e. unit and e2e tests)
 .PHONY: test-unit
 test-unit: vet fmt ginkgo ## Run unit tests.
 ifneq ($(SKIP_TESTS), true)
-	$(GINKGO) -v -output-dir=. -cover -coverpkg=./... -r -coverprofile cover.out  ./pkg ./cmd
+	$(GINKGO) -v -output-dir=. -cover -coverpkg=./... -r -coverprofile cover.out ./pkg ./cmd
 endif
 
 ## E2E Tests
@@ -93,7 +93,7 @@ endif
 .PHONY: e2e-teardown
 e2e-teardown: ## Tearing environment for e2e tests.
 ifneq ($(SKIP_TESTS), true)
-	./scripts/e2e_cleanup.sh
+	- ./scripts/e2e_cleanup.sh
 endif
 
 ##@ Install tools

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -66,7 +66,7 @@ func NewRootCmd() *cobra.Command {
 			}
 		},
 		PersistentPostRun: func(cmd *cobra.Command, args []string) {
-			kubeConfig.ContextOptions.Cancel()
+			kubeConfig.CancelContext()
 		},
 	}
 

--- a/e2e/e2e_test.go
+++ b/e2e/e2e_test.go
@@ -150,7 +150,7 @@ var _ = Describe("kubectl ephemeral-containers", func() {
 				actual, err := tr.RunPluginEditCmd(tr.Kubectl.Namespace, testutils.TestPodName)
 
 				Expect(err).ToNot(HaveOccurred())
-				Expect(actual).To(Equal(fmt.Sprintf("Edit cancelled, no changes made for pod/%s\n", testutils.PodName)))
+				Expect(actual).To(Equal(fmt.Sprintf("Edit cancelled, no changes made for pod/%s\n", testutils.TestPodName)))
 			})
 		})
 
@@ -165,7 +165,7 @@ var _ = Describe("kubectl ephemeral-containers", func() {
 				actual, err := tr.RunPluginEditCmd(tr.Kubectl.Namespace, testutils.TestPodName)
 
 				Expect(err).To(HaveOccurred())
-				Expect(actual).To(ContainSubstring(fmt.Sprintf("Pod \"%s\" is invalid: spec.ephemeralContainers: Forbidden: existing ephemeral containers \"%s\" may not be changed", testutils.PodName, testutils.EphContainerName)))
+				Expect(actual).To(ContainSubstring(fmt.Sprintf("Pod \"%s\" is invalid: spec.ephemeralContainers: Forbidden: existing ephemeral containers \"%s\" may not be changed", testutils.TestPodName, testutils.EphContainerName)))
 			})
 		})
 
@@ -180,7 +180,7 @@ var _ = Describe("kubectl ephemeral-containers", func() {
 				actual, err := tr.RunPluginEditCmd(tr.Kubectl.Namespace, testutils.TestPodName)
 
 				Expect(err).To(HaveOccurred())
-				Expect(actual).To(ContainSubstring(fmt.Sprintf("Pod \"%s\" is invalid: spec.ephemeralContainers: Forbidden: existing ephemeral containers \"%s\" may not be removed", testutils.PodName, testutils.EphContainerName)))
+				Expect(actual).To(ContainSubstring(fmt.Sprintf("Pod \"%s\" is invalid: spec.ephemeralContainers: Forbidden: existing ephemeral containers \"%s\" may not be removed", testutils.TestPodName, testutils.EphContainerName)))
 			})
 		})
 

--- a/e2e/testutils/resources.go
+++ b/e2e/testutils/resources.go
@@ -31,7 +31,6 @@ var (
 	TestPodName      string = "plugin-e2e"
 	DebugImage       string = "docker.io/library/busybox:1.28"
 	EphContainerName string = "debugger"
-	PodName          string = "plugin-e2e"
 )
 
 func (t *TestResource) NewListOutput(format string, namespace string) string {
@@ -60,7 +59,7 @@ func (t *TestResource) newListInAllNamespaces(format string) string {
     ]
   }
 ]
-`, PodName, t.Kubectl.Namespace, EphContainerName, PodName, t.AnotherNamespace, EphContainerName,
+`, TestPodName, t.Namespace, EphContainerName, TestPodName, t.AnotherNamespace, EphContainerName,
 		)
 	case "yaml":
 		return fmt.Sprintf(`- ephemeralContainers:
@@ -72,7 +71,7 @@ func (t *TestResource) newListInAllNamespaces(format string) string {
   name: %s
   namespace: %s
 
-`, EphContainerName, PodName, t.Kubectl.Namespace, EphContainerName, PodName, t.AnotherNamespace)
+`, EphContainerName, TestPodName, t.Namespace, EphContainerName, TestPodName, t.AnotherNamespace)
 	default: // table or empty
 		return fmt.Sprintf(
 			`+------------+-----------+----------------------+
@@ -82,7 +81,7 @@ func (t *TestResource) newListInAllNamespaces(format string) string {
 | %s | %s | %s             |
 +------------+-----------+----------------------+
 
-`, PodName, t.Kubectl.Namespace, EphContainerName, PodName, t.AnotherNamespace, EphContainerName)
+`, TestPodName, t.Namespace, EphContainerName, TestPodName, t.AnotherNamespace, EphContainerName)
 	}
 }
 
@@ -98,7 +97,7 @@ func (t *TestResource) newListInNamespace(format string, namespace string) strin
     ]
   }
 ]
-`, PodName, namespace, EphContainerName,
+`, TestPodName, namespace, EphContainerName,
 		)
 	case "yaml":
 		return fmt.Sprintf(`- ephemeralContainers:
@@ -106,7 +105,7 @@ func (t *TestResource) newListInNamespace(format string, namespace string) strin
   name: %s
   namespace: %s
 
-`, EphContainerName, PodName, t.Kubectl.Namespace)
+`, EphContainerName, TestPodName, t.Namespace)
 	default: // table or empty
 		return fmt.Sprintf(
 			`+------------+-----------+----------------------+
@@ -115,7 +114,7 @@ func (t *TestResource) newListInNamespace(format string, namespace string) strin
 | %s | %s | %s             |
 +------------+-----------+----------------------+
 
-`, PodName, namespace, EphContainerName)
+`, TestPodName, namespace, EphContainerName)
 	}
 }
 


### PR DESCRIPTION
### Description

The PR includes the following changes.

**Tests**

- Added assertions for command flags (both persistent and local ones).

**Fixes**

- Fixed potential empty context when accessing from non-main goroutine (i.e. used for handling OS signals).

**Other chores**

- Bumped ginkgo executable version to match module version (i.e. `v2.22.1`).
- Configure `e2e-teardown` to ignore failure. This will be beneficial in CI environment where cleanup failures does not fail the entire test process.
- Used embedded fields for for e2e `TestResource` struct to simplifying field references.
- Removed duplicate/unused variables.


Fixes #7 
<!---
Related to #<issue number>
Depends on #<issue number>
-->

### Type of change

Please select the type of change(s) this PR introduces:
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Code clean up
- [ ] Documentation update
- [x] Tests
### Checklist

- [x] I have read the [Contributing Guidelines](/CONTRIBUTING.md) document
- [x] I have include additional documentations if the PR includes user-facing changes
- [x] I have signed my commits. See [references](https://docs.github.com/en/authentication/managing-commit-signature-verification/about-commit-signature-verification) for more details

### Additional Information

I apologize for condensing the changes in a single PR, however, they are somewhat inter-dependent.